### PR TITLE
Use deliveryMode=2 to make messages persist

### DIFF
--- a/pushback.py
+++ b/pushback.py
@@ -31,7 +31,7 @@ def process_file(path: str, filename: str):
         logger.info("Not pushing messages, remove --dry-run to do this")
     else:
         logger.info("Pushing to {0} with roting key {1}".format(args.exchange, routing_key))
-        props = pika.BasicProperties(content_type="application/json",content_encoding="UTF-8", message_id=message_id)
+        props = pika.BasicProperties(content_type="application/json",content_encoding="UTF-8", message_id=message_id, delivery_mode=2)
         channel.basic_publish(args.exchange, routing_key, content, props)
 
 


### PR DESCRIPTION
delivery_mode in rabbitMQ determines if messages will be stored on disk after the broker restarts. You can mark messages as persistent by seting delivery_mode = 2 when you publish a message.